### PR TITLE
CI追加: Lint & Build チェック（Issue #2）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  lint-and-build:
+    name: Lint & Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Build
+        run: npm run build


### PR DESCRIPTION
## Summary
- `.github/workflows/ci.yml` を新規追加
- PRおよびmain直pushでLint・Buildを自動検査
- 失敗時はステータスチェック失敗としてPRに表示

## 背景
Issue #2 で依頼した「ESLintエラーでVercel本番デプロイが失敗する事象の再発防止CI」の実装。

## 検証計画
- [ ] このPR自身でCIが走り、`Lint & Build` ジョブが成功することを確認
- [ ] マージ後、Settings → Branches → main に Branch Protection Rules を設定し `Lint & Build` を必須化

## 注意
マージした時点ではまだ必須チェックではない。マージ後にBranch Protection設定が必要。

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)