### PR TITLE
feat(v4): Phase 4 Pre-mortem 実装 + 仮説ラベル + 軽量複数シナリオ拡張

### DIFF
--- a/src/app/api/pipeline/premortem-variant/route.ts
+++ b/src/app/api/pipeline/premortem-variant/route.ts
@@ -1,0 +1,57 @@
+// Socra v4 軽量複数シナリオ拡張: Pre-mortem Variant 単体実行 API
+// 2026-04-25 追加: 既存 Pre-mortem の後に「別の壊し方を見る」で呼ばれる。
+// セッション状態（structured/facts/agents/verification）はクライアントから渡す。
+import { runPreMortemVariant } from '@/lib/pipeline/engine'
+import type { StructuredQuestion, Fact, AgentResponse, VerificationResult } from '@/types'
+
+export const maxDuration = 60  // Pre-mortem 単体は20-30秒。余裕を持って60秒。
+export const dynamic = 'force-dynamic'
+
+interface VariantRequest {
+  structured: StructuredQuestion
+  facts: Fact[]
+  agents: AgentResponse[]
+  verification: VerificationResult
+  avoidScenarios: string[]
+}
+
+export async function POST(req: Request) {
+  let body: VariantRequest
+  try {
+    body = await req.json() as VariantRequest
+  } catch {
+    return new Response(JSON.stringify({ error: 'invalid json' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  const { structured, facts, agents, verification, avoidScenarios } = body
+
+  if (!structured || !structured.clarified) {
+    return new Response(JSON.stringify({ error: 'structured question is required' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  try {
+    const variant = await runPreMortemVariant(
+      structured,
+      facts ?? [],
+      agents ?? [],
+      verification ?? { hat: 'blue', model: 'openai', contradictions: [], factGaps: [], overallConsistency: 100 },
+      avoidScenarios ?? [],
+    )
+    return new Response(JSON.stringify(variant), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'variant generation failed'
+    return new Response(JSON.stringify({ error: msg }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+}

--- a/src/app/api/pipeline/route.ts
+++ b/src/app/api/pipeline/route.ts
@@ -1,6 +1,6 @@
 // Socra パイプライン SSE エンドポイント
 // 5段パイプラインを順次実行し、各ステージの結果をSSEでストリーミング
-import { runStructure, runObserve, runDeliberateSequential, runVerify, runSynthesize, runRouting, runFocusPoint } from '@/lib/pipeline/engine'
+import { runStructure, runObserve, runDeliberateSequential, runVerify, runSynthesize, runRouting, runFocusPoint, runPreMortem } from '@/lib/pipeline/engine'
 import { detectCrisis, getCrisisResponse } from '@/lib/safety'
 import type { SSEEvent, MemoryContext } from '@/types'
 
@@ -155,6 +155,21 @@ export async function POST(req: Request) {
           const verification = await runVerify(structured, deliberation.agents)
           send({ type: 'stage:complete', stage: 'verify', data: verification, timestamp: now() })
 
+          // ── Stage 3.5: 叡 — Pre-mortem（v4 Phase 4・時間の座）────
+          // round 0（初回）のみ実行。フォローアップラウンドでは叡は現在に戻って対話する。
+          let preMortem = null
+          if (round === 0) {
+            send({ type: 'stage:start', stage: 'premortem', data: null, timestamp: now() })
+            try {
+              preMortem = await runPreMortem(structured, observation.facts, deliberation.agents, verification)
+              send({ type: 'stage:complete', stage: 'premortem', data: preMortem, timestamp: now() })
+            } catch (err) {
+              // Pre-mortem 失敗時は pipeline 全体を落とさず、synthesize へ続行
+              const msg = err instanceof Error ? err.message : 'premortem failed'
+              send({ type: 'stage:complete', stage: 'premortem', data: { error: msg }, timestamp: now() })
+            }
+          }
+
           // ── Stage 4: 青/統合 ────────────────────────
           send({ type: 'stage:start', stage: 'synthesize', data: null, timestamp: now() })
           const synthesis = await runSynthesize(structured, observation.facts, deliberation.agents, verification, undefined, userName, round, memoryContext)
@@ -163,7 +178,7 @@ export async function POST(req: Request) {
           // ── 完了 ────────────────────────────────────
           send({
             type: 'pipeline:complete',
-            data: { structured, observation, deliberation, verification, synthesis, routing },
+            data: { structured, observation, deliberation, verification, preMortem, synthesis, routing },
             timestamp: now(),
           })
         }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1021,6 +1021,69 @@ function StreamEntry({ entry, pipeline, expanded, onToggle, locale, onAgentFocus
             </p>
           </div>
         )}
+
+        {/* v4 軽量複数シナリオ拡張: 「別の壊し方を見る」 */}
+        {pipeline.preMortemVariants.length > 0 && (
+          <div className="mt-5 space-y-3">
+            {pipeline.preMortemVariants.map((v, i) => (
+              <div
+                key={`variant-${i}`}
+                className="rounded-lg p-3"
+                style={{
+                  background: '#0f172a',
+                  border: `1px solid ${blue}30`,
+                  color: '#cbd5e1',
+                }}
+              >
+                <p className="text-[10px] uppercase tracking-wider mb-1.5" style={{ color: '#64748b' }}>
+                  別の壊し方 / Another way it could break · {i + 1}
+                </p>
+                {v.scenarioTitle && (
+                  <p className="text-sm font-semibold leading-snug mb-2" style={{ color: '#e2e8f0' }}>
+                    &ldquo;{v.scenarioTitle}&rdquo;
+                  </p>
+                )}
+                {v.narrative && (
+                  <p className="text-xs leading-relaxed mb-2" style={{ color: '#94a3b8' }}>
+                    {v.narrative}
+                  </p>
+                )}
+                {v.coreQuestionBack && (
+                  <p className="text-xs italic mt-2 pt-2 border-t leading-relaxed" style={{ borderColor: `${blue}20`, color: blue }}>
+                    &ldquo;{v.coreQuestionBack}&rdquo;
+                  </p>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+
+        {pipeline.preMortemVariants.length < 3 && (
+          <div className="mt-4 pt-3 border-t" style={{ borderColor: `${blue}20` }}>
+            <button
+              type="button"
+              onClick={() => pipeline.loadPreMortemVariant()}
+              disabled={pipeline.variantLoading}
+              className="text-[11px] tracking-wide px-3 py-1.5 rounded-md transition-opacity disabled:opacity-40 hover:opacity-80"
+              style={{
+                background: 'transparent',
+                border: `1px solid ${blue}40`,
+                color: '#94a3b8',
+              }}
+            >
+              {pipeline.variantLoading
+                ? '叡がもう一つの未来を見ている…'
+                : pipeline.preMortemVariants.length === 0
+                  ? '別の壊し方を見る ↓'
+                  : 'さらに別の壊し方を見る ↓'}
+            </button>
+            {pipeline.variantError && (
+              <p className="text-[10px] mt-2" style={{ color: '#fca5a5' }}>
+                {pipeline.variantError}
+              </p>
+            )}
+          </div>
+        )}
       </div>
     )
   }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -941,6 +941,18 @@ function StreamEntry({ entry, pipeline, expanded, onToggle, locale, onAgentFocus
           </div>
         </div>
 
+        {pm.disclaimer && (
+          <div
+            className="mb-4 px-3 py-2 rounded-md flex items-start gap-2"
+            style={{ background: '#0f172a', border: '1px solid #334155' }}
+          >
+            <span className="text-[10px] mt-0.5 font-bold" style={{ color: '#fbbf24' }}>※</span>
+            <p className="text-[11px] leading-relaxed" style={{ color: '#cbd5e1' }}>
+              {pm.disclaimer}
+            </p>
+          </div>
+        )}
+
         {pm.scenarioTitle && (
           <p className="text-lg font-semibold leading-snug mb-3" style={{ color: '#f1f5f9' }}>
             &ldquo;{pm.scenarioTitle}&rdquo;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -916,6 +916,103 @@ function StreamEntry({ entry, pipeline, expanded, onToggle, locale, onAgentFocus
     )
   }
 
+  // 叡の Pre-mortem（v4 Phase 4・時間の座）— 3年後から振り返る
+  if (entry.type === 'synthesis' && entry.stage === 'premortem') {
+    const pm = pipeline.preMortem
+    if (!pm || !pm.narrative) return null
+
+    const blue = AGENTS.blue.hex
+    return (
+      <div
+        className="rounded-xl p-5 mt-2 relative overflow-hidden"
+        style={{
+          background: `linear-gradient(135deg, #0b1220 0%, #111827 60%, ${blue}14 100%)`,
+          border: `2px solid ${blue}40`,
+          color: '#e5e7eb',
+        }}
+      >
+        <div className="flex items-center gap-2 mb-3">
+          <div className="w-8 h-8 rounded-full flex items-center justify-center" style={{ backgroundColor: `${blue}22` }}>
+            <span className="text-sm font-bold" style={{ color: blue }}>叡</span>
+          </div>
+          <div>
+            <span className="text-sm font-semibold" style={{ color: blue }}>Ei — Three Years From Now</span>
+            <p className="text-[10px]" style={{ color: '#94a3b8' }}>叡が時間の座から語る / Speaking from the Seat of Time</p>
+          </div>
+        </div>
+
+        {pm.scenarioTitle && (
+          <p className="text-lg font-semibold leading-snug mb-3" style={{ color: '#f1f5f9' }}>
+            &ldquo;{pm.scenarioTitle}&rdquo;
+          </p>
+        )}
+
+        <p className="text-sm leading-relaxed mb-4" style={{ color: '#cbd5e1' }}>
+          {pm.narrative}
+        </p>
+
+        {pm.rootCauses.length > 0 && (
+          <div className="mb-4">
+            <p className="text-[10px] uppercase tracking-wider mb-2" style={{ color: '#94a3b8' }}>
+              What caused the failure / 何がそれを招いたのか
+            </p>
+            <ul className="space-y-1.5">
+              {pm.rootCauses.map((c, i) => (
+                <li key={i} className="flex items-start gap-2">
+                  <span className="w-1 h-1 rounded-full mt-2 flex-shrink-0" style={{ backgroundColor: blue }} />
+                  <span className="text-xs leading-relaxed" style={{ color: '#e2e8f0' }}>{c}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {pm.warningSigns.length > 0 && (
+          <div className="mb-4">
+            <p className="text-[10px] uppercase tracking-wider mb-2" style={{ color: '#94a3b8' }}>
+              Early warning signs / 早期警戒サイン
+            </p>
+            <ul className="space-y-1.5">
+              {pm.warningSigns.map((w, i) => (
+                <li key={i} className="flex items-start gap-2">
+                  <span className="w-1 h-1 rounded-full mt-2 flex-shrink-0" style={{ backgroundColor: '#f59e0b' }} />
+                  <span className="text-xs leading-relaxed" style={{ color: '#e2e8f0' }}>{w}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {pm.retractionTriggers.length > 0 && (
+          <div className="mb-4 p-3 rounded-lg" style={{ background: '#1f2937', border: '1px solid #374151' }}>
+            <p className="text-[10px] uppercase tracking-wider mb-2" style={{ color: '#f87171' }}>
+              Retraction triggers / 撤回条件
+            </p>
+            <ul className="space-y-1.5">
+              {pm.retractionTriggers.map((t, i) => (
+                <li key={i} className="flex items-start gap-2">
+                  <span className="text-[10px] mt-0.5 font-bold" style={{ color: '#f87171' }}>◆</span>
+                  <span className="text-xs leading-relaxed font-medium" style={{ color: '#fca5a5' }}>{t}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {pm.coreQuestionBack && (
+          <div className="mt-4 pt-4 border-t" style={{ borderColor: `${blue}30` }}>
+            <p className="text-[10px] uppercase tracking-wider mb-2" style={{ color: '#94a3b8' }}>
+              Returning to the present / 現在に戻って、叡があなたに問う
+            </p>
+            <p className="text-base font-medium italic leading-relaxed" style={{ color: blue }}>
+              &ldquo;{pm.coreQuestionBack}&rdquo;
+            </p>
+          </div>
+        )}
+      </div>
+    )
+  }
+
   // 叡の統合（メンター — 視覚的に区別）
   if (entry.type === 'synthesis') {
     const synthesis = pipeline.synthesis

--- a/src/components/DecisionMap.tsx
+++ b/src/components/DecisionMap.tsx
@@ -537,6 +537,7 @@ export default function DecisionMap({ pipeline, onNodeClick, theme, round }: Pro
     observe: 'Mei gathering facts...',
     deliberate: 'Team deliberating...',
     verify: 'Ri verifying logic...',
+    premortem: 'Ei remembering from three years ahead...',
     synthesize: 'Ei synthesizing...',
   }[pipeline.currentStage] : null
 

--- a/src/lib/pipeline/engine.ts
+++ b/src/lib/pipeline/engine.ts
@@ -248,6 +248,59 @@ export async function runPreMortem(
   }
 }
 
+// ── Stage 3.5b: Pre-mortem Variant（v4 軽量複数シナリオ拡張）──────
+// 2026-04-25 追加: 既出シナリオを除外し、別角度の失敗を生成。
+export async function runPreMortemVariant(
+  sq: StructuredQuestion,
+  facts: Fact[],
+  agents: AgentResponse[],
+  verification: VerificationResult,
+  avoidScenarios: string[],
+): Promise<PreMortemResult> {
+  const { text } = await generateText({
+    model: models.synthesize,
+    prompt: prompts.premortemVariant(sq, facts, agents, verification, avoidScenarios),
+  })
+
+  const defaultDisclaimer =
+    'これは未来から語られた仮想シナリオです。登場する数字（金額・月数・週数・割合）は予測ではなく、思考のための仮置き値です。あなたの状況に合わせて調整してください。'
+
+  const fallback: PreMortemResult = {
+    hat: 'blue',
+    model: 'claude',
+    scenarioTitle: '',
+    narrative: text.slice(0, 500),
+    rootCauses: [],
+    warningSigns: [],
+    retractionTriggers: [],
+    coreQuestionBack: '',
+    disclaimer: defaultDisclaimer,
+  }
+
+  const jsonMatch = text.match(/```json\s*([\s\S]*?)```/) ?? text.match(/\{[\s\S]*\}/)
+  if (!jsonMatch) return fallback
+
+  try {
+    const jsonStr = jsonMatch[1] ?? jsonMatch[0]
+    const parsed = JSON.parse(jsonStr) as Partial<PreMortemResult>
+    return {
+      hat: 'blue',
+      model: 'claude',
+      scenarioTitle: typeof parsed.scenarioTitle === 'string' ? parsed.scenarioTitle : '',
+      narrative: typeof parsed.narrative === 'string' ? parsed.narrative : fallback.narrative,
+      rootCauses: Array.isArray(parsed.rootCauses) ? parsed.rootCauses.filter(s => typeof s === 'string') : [],
+      warningSigns: Array.isArray(parsed.warningSigns) ? parsed.warningSigns.filter(s => typeof s === 'string') : [],
+      retractionTriggers: Array.isArray(parsed.retractionTriggers) ? parsed.retractionTriggers.filter(s => typeof s === 'string') : [],
+      coreQuestionBack: typeof parsed.coreQuestionBack === 'string' ? parsed.coreQuestionBack : '',
+      disclaimer: typeof parsed.disclaimer === 'string' && parsed.disclaimer.trim().length > 0
+        ? parsed.disclaimer
+        : defaultDisclaimer,
+    }
+  } catch {
+    return fallback
+  }
+}
+
 // ── Stage 4: 叡（Ei）— 統合（Claude）────────────────
 export async function runSynthesize(
   sq: StructuredQuestion,

--- a/src/lib/pipeline/engine.ts
+++ b/src/lib/pipeline/engine.ts
@@ -209,6 +209,10 @@ export async function runPreMortem(
 
   // JSON 抽出（コードフェンス or 生 JSON）
   const jsonMatch = text.match(/```json\s*([\s\S]*?)```/) ?? text.match(/\{[\s\S]*\}/)
+  // v4 安全装置: モデルが disclaimer を出さなかった場合のデフォルト文言
+  const defaultDisclaimer =
+    'これは未来から語られた仮想シナリオです。登場する数字（金額・月数・週数・割合）は予測ではなく、思考のための仮置き値です。あなたの状況に合わせて調整してください。'
+
   const fallback: PreMortemResult = {
     hat: 'blue',
     model: 'claude',
@@ -218,6 +222,7 @@ export async function runPreMortem(
     warningSigns: [],
     retractionTriggers: [],
     coreQuestionBack: '',
+    disclaimer: defaultDisclaimer,
   }
 
   if (!jsonMatch) return fallback
@@ -234,6 +239,9 @@ export async function runPreMortem(
       warningSigns: Array.isArray(parsed.warningSigns) ? parsed.warningSigns.filter(s => typeof s === 'string') : [],
       retractionTriggers: Array.isArray(parsed.retractionTriggers) ? parsed.retractionTriggers.filter(s => typeof s === 'string') : [],
       coreQuestionBack: typeof parsed.coreQuestionBack === 'string' ? parsed.coreQuestionBack : '',
+      disclaimer: typeof parsed.disclaimer === 'string' && parsed.disclaimer.trim().length > 0
+        ? parsed.disclaimer
+        : defaultDisclaimer,
     }
   } catch {
     return fallback

--- a/src/lib/pipeline/engine.ts
+++ b/src/lib/pipeline/engine.ts
@@ -12,6 +12,7 @@ import type {
   DeliberationResult,
   VerificationResult,
   SynthesisResult,
+  PreMortemResult,
   HatColor,
   Fact,
   MemoryContext,
@@ -190,6 +191,53 @@ export async function runVerify(
   })
 
   return { hat: 'blue', model: 'openai', ...object }
+}
+
+// ── Stage 3.5: 叡（Ei）— Pre-mortem（v4 Phase 4・時間の座）──────
+// 2026-04-24 v4 追加: 提出前レッドチームの心臓。
+// Claude Opus 4.7 で実行（models.synthesize と同じ枠・最高推論が必要）。
+export async function runPreMortem(
+  sq: StructuredQuestion,
+  facts: Fact[],
+  agents: AgentResponse[],
+  verification: VerificationResult,
+): Promise<PreMortemResult> {
+  const { text } = await generateText({
+    model: models.synthesize,
+    prompt: prompts.premortem(sq, facts, agents, verification),
+  })
+
+  // JSON 抽出（コードフェンス or 生 JSON）
+  const jsonMatch = text.match(/```json\s*([\s\S]*?)```/) ?? text.match(/\{[\s\S]*\}/)
+  const fallback: PreMortemResult = {
+    hat: 'blue',
+    model: 'claude',
+    scenarioTitle: '',
+    narrative: text.slice(0, 500),
+    rootCauses: [],
+    warningSigns: [],
+    retractionTriggers: [],
+    coreQuestionBack: '',
+  }
+
+  if (!jsonMatch) return fallback
+
+  try {
+    const jsonStr = jsonMatch[1] ?? jsonMatch[0]
+    const parsed = JSON.parse(jsonStr) as Partial<PreMortemResult>
+    return {
+      hat: 'blue',
+      model: 'claude',
+      scenarioTitle: typeof parsed.scenarioTitle === 'string' ? parsed.scenarioTitle : '',
+      narrative: typeof parsed.narrative === 'string' ? parsed.narrative : fallback.narrative,
+      rootCauses: Array.isArray(parsed.rootCauses) ? parsed.rootCauses.filter(s => typeof s === 'string') : [],
+      warningSigns: Array.isArray(parsed.warningSigns) ? parsed.warningSigns.filter(s => typeof s === 'string') : [],
+      retractionTriggers: Array.isArray(parsed.retractionTriggers) ? parsed.retractionTriggers.filter(s => typeof s === 'string') : [],
+      coreQuestionBack: typeof parsed.coreQuestionBack === 'string' ? parsed.coreQuestionBack : '',
+    }
+  } catch {
+    return fallback
+  }
 }
 
 // ── Stage 4: 叡（Ei）— 統合（Claude）────────────────

--- a/src/lib/pipeline/prompts.ts
+++ b/src/lib/pipeline/prompts.ts
@@ -410,6 +410,95 @@ Key Points: ${a.keyPoints.join('; ')}`).join('\n\n')}
 
 IMPORTANT: Respond in the SAME LANGUAGE as the decision question. If the question is in Japanese, ALL output must be in Japanese.`),
 
+  // ── Stage 3.5: 叡（Ei）— Pre-mortem（v4 Phase 4・時間の座）────
+  // 2026-04-24 v4 追加: Socra の心臓部。「提出前レッドチーム」として
+  // 「3年後、この決定は失敗だった。何がそれを招いたのか。」を叡が語る。
+  // 出典: Klein (2007) "Performing a Project Premortem" / Kahneman (2011) "Thinking, Fast and Slow"
+  premortem: (
+    sq: StructuredQuestion,
+    facts: Fact[],
+    agents: AgentResponse[],
+    verification: VerificationResult,
+  ) => withFoundation(`You are Ei (叡) — but not as you usually are. In this moment, you occupy **the Seat of Time**.
+
+You are no longer speaking from the present. You are speaking from **three years in the future**, looking back at the decision the user is about to make today. In that future, this decision has already failed. You lived through the failure. You know exactly how it unraveled.
+
+## Your Role in This Phase
+You are the voice from the future who comes back to warn — not to frighten, but to make the failure concrete enough that the user can prevent it. This is the *pre-mortem* (Klein, 2007): by imagining the failure as if it already happened, the mind generates specific, plausible causes that forward-looking analysis systematically misses.
+
+This is the most important moment of the entire Socra session. The user has heard four perspectives, seen the logic verification, and is tempted to move forward. Your job is to **fracture that premature confidence** by delivering the one imagined reality that their forward-looking brain cannot generate on its own: a detailed, specific, believable failure.
+
+## The Core Question You Must Answer
+**"Three years from now, this decision turned out to be a failure. What caused it?"**
+**「3年後、この決定は失敗だった。何がそれを招いたのか。」**
+
+## The Decision Under Examination
+"${sq.clarified}"
+
+## Time Horizon: ${sq.timeHorizon}
+## Reversibility: ${sq.reversibility}
+## Stakeholders: ${sq.stakeholders.join(', ')}
+
+## What Mei Found
+${facts.length > 0 ? facts.map(f => `- [${f.confidence}] ${f.content}`).join('\n') : '- (no prior facts)'}
+
+## What Your Team Said
+${agents.map(a => `### ${a.name} (${a.hat}) — ${a.stance}, intensity ${a.intensity}/5
+${a.reasoning}
+Key: ${a.keyPoints.join(' | ')}`).join('\n\n')}
+
+## What Ri Verified
+- Consistency: ${verification.overallConsistency}/100
+- Contradictions: ${verification.contradictions.length > 0 ? verification.contradictions.map(c => `${c.hat1} vs ${c.hat2}: ${c.description}`).join('; ') : 'None'}
+- Fact Gaps: ${verification.factGaps.length > 0 ? verification.factGaps.join('; ') : 'None'}
+
+## Your Task
+
+You will write from the future. It is three years after the decision. The failure is complete. You are telling the user what happened.
+
+Produce the following, each in the user's language:
+
+1. **scenarioTitle** (one line, 15–30 characters in Japanese / 5–10 words in English)
+   A concrete title for the failure. Not "the project failed" — something specific like "3年後、拡大は内部崩壊で頓挫した" or "The expansion collapsed from within, not from competition."
+
+2. **narrative** (3–5 sentences)
+   Write in past tense. Describe HOW it failed. Specific events, specific decisions, specific moments where it went wrong. Make it feel like a memory, not a prediction. Example:
+   "彼らは順調に見えた最初の1年で、核となる3人が疲弊した。2年目、その3人のうち1人が離職した瞬間から、顧客対応の質が目に見えて落ちた。気づいた頃には、最大顧客の信頼が戻らないほどに損なわれていた。"
+
+3. **rootCauses** (3–5 items)
+   The specific causes that led to the failure. Each should be a single sentence. These are NOT Kai's risks rephrased — Kai spoke from the present ("this could go wrong"). You speak from the future ("this is what actually broke"). Be concrete and believable.
+
+4. **warningSigns** (3–5 items)
+   Early signals the user could have noticed in the first 3–6 months that would have predicted this failure. Each should be observable in reality — not "if morale drops" but "if three consecutive 1-on-1s end with the employee saying they're 'fine' without elaborating."
+
+5. **retractionTriggers** (2–4 items)
+   Specific conditions that, if observed, should cause the user to pull back, pause, or reverse this decision. Each should be a bright line — measurable or unambiguous. Example: "If ARR growth drops below 15% for two consecutive quarters AND churn exceeds 8%, retract."
+
+6. **coreQuestionBack** (one sentence, question form)
+   You return from the future to the present. You look the user in the eye and ask the ONE question that, if they answer honestly today, prevents this future. This is not a reflective "what do you think?" question — it's a specific, piercing question that forces the user to confront the assumption most likely to break. The user's own answer is the product; your question must make that answer possible.
+
+## CRITICAL RULES — Pre-mortem Integrity
+
+- **DO NOT repeat Kai's risks verbatim.** Kai speaks from the present. You speak from the future. If Kai said "there's a risk of burnout," you say "in month 14, the burnout showed up as a 40% drop in code review quality, which nobody noticed until the first customer incident." Specificity is what makes pre-mortem work.
+- **DO NOT hedge.** You are not predicting — you are remembering. "It probably would..." is forbidden. Use "it did," "they found," "by month 18..."
+- **DO NOT give balanced airtime to success.** The deliberate phase already did that. Your job is to make the failure concrete. Balance comes later from Ei in the synthesis phase.
+- **DO NOT invent facts the user didn't provide.** If the user didn't mention their team size, don't say "all 12 employees left." Say "the key people left" — specific in pattern, general in numbers.
+- **DO NOT moralize.** You are not judging the user's choice. You are showing them one plausible future so they can decide whether they can live with it.
+- **Every cause, sign, and trigger must be specific enough that the user could check it against reality.** Vague warnings are useless. "Morale will drop" is useless. "When your best engineer starts declining 1-on-1s, that's the sign" is useful.
+
+## Output Format (JSON ONLY, no markdown fences, no prose before or after)
+
+{
+  "scenarioTitle": "string",
+  "narrative": "string",
+  "rootCauses": ["string", "string", "string"],
+  "warningSigns": ["string", "string", "string"],
+  "retractionTriggers": ["string", "string"],
+  "coreQuestionBack": "string ending with ?"
+}
+
+CRITICAL: Respond in the SAME LANGUAGE as the decision question. If the question is in Japanese, ALL fields must be in Japanese. Output ONLY valid JSON — no prose, no markdown.`),
+
   // ── Stage 4: 叡（Ei）— 統合・メンター（Claude）────
   synthesize: (
     sq: StructuredQuestion,

--- a/src/lib/pipeline/prompts.ts
+++ b/src/lib/pipeline/prompts.ts
@@ -480,11 +480,19 @@ Produce the following, each in the user's language:
 ## CRITICAL RULES — Pre-mortem Integrity
 
 - **DO NOT repeat Kai's risks verbatim.** Kai speaks from the present. You speak from the future. If Kai said "there's a risk of burnout," you say "in month 14, the burnout showed up as a 40% drop in code review quality, which nobody noticed until the first customer incident." Specificity is what makes pre-mortem work.
-- **DO NOT hedge.** You are not predicting — you are remembering. "It probably would..." is forbidden. Use "it did," "they found," "by month 18..."
+- **DO NOT hedge inside the narrative.** You are not predicting — you are remembering. "It probably would..." is forbidden. Use "it did," "they found," "by month 18..."
 - **DO NOT give balanced airtime to success.** The deliberate phase already did that. Your job is to make the failure concrete. Balance comes later from Ei in the synthesis phase.
 - **DO NOT invent facts the user didn't provide.** If the user didn't mention their team size, don't say "all 12 employees left." Say "the key people left" — specific in pattern, general in numbers.
 - **DO NOT moralize.** You are not judging the user's choice. You are showing them one plausible future so they can decide whether they can live with it.
 - **Every cause, sign, and trigger must be specific enough that the user could check it against reality.** Vague warnings are useless. "Morale will drop" is useless. "When your best engineer starts declining 1-on-1s, that's the sign" is useful.
+
+## CRITICAL RULE — Hypothetical Labeling (v4 safety, 2026-04-25)
+
+The numbers you produce (yen / months / weeks / percentages / cash thresholds) are **placeholders for thinking, not predictions**. The user must NOT mistake them for forecasts. You handle this in two places:
+
+1. **Inside narrative / rootCauses**: keep them concrete and unhedged. The future-completed voice depends on this.
+2. **Inside retractionTriggers**: every trigger MUST end with a short calibration cue such as "（仮置き・あなたの状況で再校正）" / "(placeholder — calibrate to your reality)". Do not soften the threshold itself; only mark that the value is a thinking aid.
+3. **Inside disclaimer (mandatory field, see Output Format)**: state in 1〜2 sentences that this is a hypothetical scenario and the numbers are illustrative thresholds the user must adjust to their own situation. This is what separates pre-mortem from prediction. Skip it and the system breaks.
 
 ## Output Format (JSON ONLY, no markdown fences, no prose before or after)
 
@@ -493,8 +501,9 @@ Produce the following, each in the user's language:
   "narrative": "string",
   "rootCauses": ["string", "string", "string"],
   "warningSigns": ["string", "string", "string"],
-  "retractionTriggers": ["string", "string"],
-  "coreQuestionBack": "string ending with ?"
+  "retractionTriggers": ["string with （仮置き・あなたの状況で再校正） or equivalent calibration cue"],
+  "coreQuestionBack": "string ending with ?",
+  "disclaimer": "1-2 sentences: this is a hypothetical scenario; numbers are illustrative placeholders, not forecasts; calibrate to your situation."
 }
 
 CRITICAL: Respond in the SAME LANGUAGE as the decision question. If the question is in Japanese, ALL fields must be in Japanese. Output ONLY valid JSON — no prose, no markdown.`),

--- a/src/lib/pipeline/prompts.ts
+++ b/src/lib/pipeline/prompts.ts
@@ -508,6 +508,73 @@ The numbers you produce (yen / months / weeks / percentages / cash thresholds) a
 
 CRITICAL: Respond in the SAME LANGUAGE as the decision question. If the question is in Japanese, ALL fields must be in Japanese. Output ONLY valid JSON — no prose, no markdown.`),
 
+  // ── Stage 3.5b: 叡（Ei）— Pre-mortem Variant（v4 軽量複数シナリオ拡張）────
+  // 2026-04-25 追加: 論の「全員一致を壊す3条件」への構造的対応。
+  // 既出シナリオを avoidScenarios で除外し、別角度の失敗を生成させる。
+  premortemVariant: (
+    sq: StructuredQuestion,
+    facts: Fact[],
+    agents: AgentResponse[],
+    verification: VerificationResult,
+    avoidScenarios: string[],
+  ) => withFoundation(`You are Ei (叡), still occupying **the Seat of Time**.
+
+You have already told the user one possible failure of this decision. Now you return to a different branch of the future. **A second failure is also possible — born from a different root, a different angle, a different definition of "what failed."**
+
+Your job in this variant: tell the user about a failure that does **NOT** repeat the angle you already gave them. If the previous scenario was about money, this one is about people, or time, or identity, or external shocks — pick a fault line you have not yet exposed.
+
+## Decision Under Examination
+"${sq.clarified}"
+
+## Failure Scenarios Already Told (you MUST avoid these angles)
+${avoidScenarios.length > 0 ? avoidScenarios.map((s, i) => `${i + 1}. ${s}`).join('\n') : '(none yet)'}
+
+## Time Horizon: ${sq.timeHorizon}
+## Reversibility: ${sq.reversibility}
+## Stakeholders: ${sq.stakeholders.join(', ')}
+
+## What Mei Found
+${facts.length > 0 ? facts.map(f => `- [${f.confidence}] ${f.content}`).join('\n') : '- (no prior facts)'}
+
+## What Your Team Said
+${agents.map(a => `### ${a.name} (${a.hat}) — ${a.stance}, intensity ${a.intensity}/5
+${a.reasoning}
+Key: ${a.keyPoints.join(' | ')}`).join('\n\n')}
+
+## Variant-Specific Constraints (READ CAREFULLY)
+
+1. **Different fault line.** Choose an axis the previous scenario(s) did not cover. Common axes:
+   - Financial collapse (cash, margin, fixed costs)
+   - Human/relational collapse (team trust, key person loss, family)
+   - Time / opportunity cost (windows missed, momentum lost elsewhere)
+   - Identity / motivation (the user lost the reason they started)
+   - External shock (market, regulation, competitor, health)
+   If the previous scenario was financial, this one MUST NOT be financial-first.
+
+2. **Different premise.** Where the previous failure assumed e.g. "the user proceeded as planned and ran out of money," this one might assume "the user succeeded financially but the success itself was the problem" or "the decision became irrelevant before it could fail or succeed."
+
+3. **Same Klein pre-mortem rules apply.**
+   - Future-completed voice ("by month 18, you found that..." — never "you might find").
+   - No hedging.
+   - Specific scenes, specific moments, specific observable details.
+   - Numbers are placeholders, marked in retractionTriggers with calibration cues.
+
+4. **Disclaimer is required, same as the original Pre-mortem.**
+
+## Output Format (JSON ONLY, no markdown fences, no prose)
+
+{
+  "scenarioTitle": "string — must NOT echo any previous title",
+  "narrative": "string — different fault line and premise",
+  "rootCauses": ["string", "string", "string"],
+  "warningSigns": ["string", "string", "string"],
+  "retractionTriggers": ["string with （仮置き・あなたの状況で再校正） or equivalent calibration cue"],
+  "coreQuestionBack": "string ending with ?",
+  "disclaimer": "1-2 sentences: this is a hypothetical scenario; numbers are illustrative placeholders, not forecasts; calibrate to your situation."
+}
+
+CRITICAL: Respond in the SAME LANGUAGE as the decision question. Output ONLY valid JSON.`),
+
   // ── Stage 4: 叡（Ei）— 統合・メンター（Claude）────
   synthesize: (
     sq: StructuredQuestion,

--- a/src/lib/usePipeline.ts
+++ b/src/lib/usePipeline.ts
@@ -32,6 +32,10 @@ export type PipelineUI = {
   agents: AgentResponse[]
   verification: VerificationResult | null
   preMortem: PreMortemResult | null
+  // v4 軽量複数シナリオ拡張: 「別の壊し方を見る」で追加生成された variants
+  preMortemVariants: PreMortemResult[]
+  variantLoading: boolean
+  variantError: string | null
   synthesis: SynthesisResult | null
   error: string | null
   // マップ成長用: 全ラウンドの累積データ
@@ -67,6 +71,9 @@ export function usePipeline() {
     agents: [],
     verification: null,
     preMortem: null,
+    preMortemVariants: [],
+    variantLoading: false,
+    variantError: null,
     synthesis: null,
     error: null,
     round: 0,
@@ -118,6 +125,9 @@ export function usePipeline() {
         agents: [],
         verification: null,
         preMortem: null,
+        preMortemVariants: [],
+        variantLoading: false,
+        variantError: null,
         synthesis: null,
         error: null,
         round: currentRound + 1,
@@ -369,6 +379,71 @@ export function usePipeline() {
     setState(prev => ({ ...prev, status: 'error', error }))
   }, [])
 
+  // v4 軽量複数シナリオ拡張: 「別の壊し方を見る」呼び出し
+  const loadPreMortemVariant = useCallback(async () => {
+    // setState の updater 内で最新スナップショットを掴む（再レンダーは最小1回）
+    let proceed = true
+    let snapshot: PipelineUI | null = null
+    setState(prev => {
+      if (prev.variantLoading || !prev.structured || !prev.preMortem) {
+        proceed = false
+        return prev
+      }
+      snapshot = prev
+      return { ...prev, variantLoading: true, variantError: null }
+    })
+    if (!proceed || !snapshot) return
+    const snap = snapshot as PipelineUI
+
+    const avoidScenarios = [
+      snap.preMortem!.scenarioTitle,
+      ...snap.preMortemVariants.map(v => v.scenarioTitle),
+    ].filter(s => typeof s === 'string' && s.trim().length > 0)
+
+    try {
+      const res = await fetch('/api/pipeline/premortem-variant', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          structured: snap.structured,
+          facts: snap.observation?.facts ?? [],
+          agents: snap.agents,
+          verification: snap.verification,
+          avoidScenarios,
+        }),
+      })
+
+      if (!res.ok) {
+        const errBody = await res.json().catch(() => ({ error: `HTTP ${res.status}` }))
+        setState(prev => ({
+          ...prev,
+          variantLoading: false,
+          variantError: typeof errBody.error === 'string' ? errBody.error : 'variant load failed',
+        }))
+        return
+      }
+
+      const variant = await res.json() as PreMortemResult
+      if (!variant || typeof variant.narrative !== 'string') {
+        setState(prev => ({ ...prev, variantLoading: false, variantError: 'invalid variant response' }))
+        return
+      }
+
+      setState(prev => ({
+        ...prev,
+        preMortemVariants: [...prev.preMortemVariants, variant],
+        variantLoading: false,
+        variantError: null,
+      }))
+    } catch (err) {
+      setState(prev => ({
+        ...prev,
+        variantLoading: false,
+        variantError: err instanceof Error ? err.message : 'variant fetch failed',
+      }))
+    }
+  }, [])
+
   // セッション復元: 過去のラウンドデータからUI状態を再構築
   const restore = useCallback((rounds: Array<{
     question?: string
@@ -471,6 +546,9 @@ export function usePipeline() {
       observation: lastRound?.observation ?? null,
       agents: lastAgents,
       preMortem: null,
+      preMortemVariants: [],
+      variantLoading: false,
+      variantError: null,
       verification: lastRound?.verification ? {
         overallConsistency: lastRound.verification.overallConsistency,
         contradictions: lastRound.verification.contradictions.map(c => ({
@@ -505,5 +583,5 @@ export function usePipeline() {
     })
   }, [])
 
-  return { ...state, run, setError, restore }
+  return { ...state, run, setError, restore, loadPreMortemVariant }
 }

--- a/src/lib/usePipeline.ts
+++ b/src/lib/usePipeline.ts
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useCallback, useRef } from 'react'
-import type { SSEEvent, PipelineStage, AgentResponse, StructuredQuestion, ObservationResult, VerificationResult, SynthesisResult, HatColor, FocusPoint, FocusPointProposal, CrossBorderRecord, DiscussionPhase, ConflictEdge } from '@/types'
+import type { SSEEvent, PipelineStage, AgentResponse, StructuredQuestion, ObservationResult, VerificationResult, SynthesisResult, PreMortemResult, HatColor, FocusPoint, FocusPointProposal, CrossBorderRecord, DiscussionPhase, ConflictEdge } from '@/types'
 
 export type TimelineEntry = {
   id: string
@@ -31,6 +31,7 @@ export type PipelineUI = {
   observation: ObservationResult | null
   agents: AgentResponse[]
   verification: VerificationResult | null
+  preMortem: PreMortemResult | null
   synthesis: SynthesisResult | null
   error: string | null
   // マップ成長用: 全ラウンドの累積データ
@@ -52,6 +53,7 @@ const STAGE_LABELS: Record<PipelineStage, string> = {
   observe: 'Mei is gathering facts...',
   deliberate: 'Your team is thinking...',
   verify: 'Ri is checking logic...',
+  premortem: 'Ei is remembering the failure from three years ahead...',
   synthesize: 'Ei is synthesizing...',
 }
 
@@ -64,6 +66,7 @@ export function usePipeline() {
     observation: null,
     agents: [],
     verification: null,
+    preMortem: null,
     synthesis: null,
     error: null,
     round: 0,
@@ -114,6 +117,7 @@ export function usePipeline() {
         observation: null,
         agents: [],
         verification: null,
+        preMortem: null,
         synthesis: null,
         error: null,
         round: currentRound + 1,
@@ -229,6 +233,28 @@ export function usePipeline() {
                   ].join('\n'),
                   timestamp: event.timestamp,
                 })
+              } else if (event.stage === 'premortem') {
+                // v4 Phase 4: Pre-mortem 結果。error ペイロードの場合はスキップ。
+                const raw = event.data as unknown
+                if (raw && typeof raw === 'object' && 'narrative' in raw) {
+                  const pm = raw as PreMortemResult
+                  setState(prev => ({ ...prev, preMortem: pm }))
+                  addTimeline({
+                    id: `ei-premortem-${Date.now()}`,
+                    type: 'synthesis',
+                    name: 'Ei',
+                    hat: 'blue',
+                    stage: 'premortem',
+                    content: [
+                      pm.scenarioTitle,
+                      '',
+                      pm.narrative,
+                      '',
+                      pm.coreQuestionBack,
+                    ].filter(Boolean).join('\n'),
+                    timestamp: event.timestamp,
+                  })
+                }
               } else if (event.stage === 'synthesize') {
                 const syn = event.data as SynthesisResult
                 setState(prev => ({ ...prev, synthesis: syn }))
@@ -444,6 +470,7 @@ export function usePipeline() {
       structured: null,
       observation: lastRound?.observation ?? null,
       agents: lastAgents,
+      preMortem: null,
       verification: lastRound?.verification ? {
         overallConsistency: lastRound.verification.overallConsistency,
         contradictions: lastRound.verification.contradictions.map(c => ({

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -120,6 +120,7 @@ export interface PreMortemResult {
   warningSigns: string[]         // 早期警戒サイン（このサインが出たら黄信号・3〜5個）
   retractionTriggers: string[]   // 撤回条件（これが起きたら引き返す・2〜4個）
   coreQuestionBack: string       // 現在に戻って叡が問う核心の問い（1文）
+  disclaimer: string             // v4 安全装置: 「これは仮想シナリオ・数字は予測ではなく仮置き」と明記する1〜2文
 }
 
 // ── Stage 4: 統合 ──────────────────────────────────────

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -28,6 +28,7 @@ export type PipelineStage =
   | 'observe'     // Stage 1: 白/観 — 事実収集
   | 'deliberate'  // Stage 2: 赤・黒・黄・緑 — 並列判断
   | 'verify'      // Stage 3: 論 — 検証
+  | 'premortem'   // Stage 3.5: 叡 — Pre-mortem（時間の座・v4 Phase 4）
   | 'synthesize'  // Stage 4: 青/統合者 — 統合
 
 export type PipelineStatus = 'pending' | 'running' | 'done' | 'error'
@@ -105,6 +106,20 @@ export interface Contradiction {
   hat2: HatColor
   description: string
   severity: 'critical' | 'moderate' | 'minor'
+}
+
+// ── Stage 3.5: Pre-mortem（v4 Phase 4・叡の「時間の座」） ────
+// 2026-04-24 v4 追加: 提出前レッドチームとしての Socra の心臓部。
+// 「3年後、この決定は失敗だった。何がそれを招いたのか。」を叡が語る。
+export interface PreMortemResult {
+  hat: 'blue'
+  model: 'claude'
+  scenarioTitle: string          // 失敗シナリオのタイトル（例: "3年後、拡大は内部崩壊で頓挫した"）
+  narrative: string              // 3年後から振り返る物語（未来完了形）
+  rootCauses: string[]           // 失敗を招いた根本原因（3〜5個）
+  warningSigns: string[]         // 早期警戒サイン（このサインが出たら黄信号・3〜5個）
+  retractionTriggers: string[]   // 撤回条件（これが起きたら引き返す・2〜4個）
+  coreQuestionBack: string       // 現在に戻って叡が問う核心の問い（1文）
 }
 
 // ── Stage 4: 統合 ──────────────────────────────────────
@@ -207,6 +222,7 @@ export interface Session {
   observation?: ObservationResult
   deliberation?: DeliberationResult
   verification?: VerificationResult
+  preMortem?: PreMortemResult
   synthesis?: SynthesisResult
   createdAt: string
   completedAt?: string


### PR DESCRIPTION
## Summary
- v4 設計の **Phase 4「Pre-mortem」** を新規追加（Klein 2007 準拠・叡が「時間の座」から3年後を語る）
- 出力ハルシネーション誤認リスクへの対応として **disclaimer 仮説ラベル機構** を追加（厳 C評価 → GO切替）
- 「全員一致を壊す3条件」への構造的対応として **軽量複数シナリオ拡張** を追加（論の指摘対応）

## 含まれるコミット
1. \`91e211a\` Phase 4 Pre-mortem 追加 — 叡が時間の座から3年後を語る
2. \`a9ad32a\` Pre-mortem に仮説ラベル機構を追加（厳C評価対応）
3. \`73ca192\` Pre-mortem 軽量複数シナリオ拡張（B案）

## 主要変更
- \`types\`: PreMortemResult 型・PipelineStage 'premortem' 追加
- \`prompts\`: premortem / premortemVariant 2本（disclaimer + calibration cue 必須化）
- \`engine\`: runPreMortem / runPreMortemVariant（Claude Opus 4.7）
- \`route.ts\`: verify → premortem → synthesize 差し込み（round 0 のみ実行）
- 新規 API: \`POST /api/pipeline/premortem-variant\`
- \`usePipeline\`: preMortem / preMortemVariants 状態 + loadPreMortemVariant
- \`page.tsx\`: 暗色グラデの Pre-mortem 専用カード + 「別の壊し方を見る」ボタン

## チーム検証結果
| レビュアー | 判定 |
|---|---|
| 厳（独立監査） | B → **HOLD → GO** へ切替（disclaimer 実装後） |
| 論（GPT-5.4 推論検証） | 条件付き Go（確信度70%）→ 仮説ラベル + 複数シナリオで主要懸念解消 |
| 燈/凛/深 | 内容は秀逸・narrative 末尾の完了形・factor 因果連鎖は別タスク |
| 風/閃/雅 | 動画素材として coreQuestionBack が最強・clip out 推奨 |
| 観（Gemini 2.5 Pro） | 類似プロダクト未確認・Originality 上位ポテンシャル |

## Test plan
- [x] 型チェック (\`tsc --noEmit\`)
- [x] Lint (\`next lint\`、新規警告なし)
- [x] ビルド (\`next build\`)
- [x] 実機テスト：採用問い・SaaS脱サラ問い（パイプライン約300秒）
- [x] variant API 単体テスト（curl・約30秒で別軸生成）
- [x] UI 結合テスト（メイン → variant ボタン → 別角度シナリオ表示）
- [ ] Vercel Preview で /api/pipeline/premortem-variant 動作確認
- [ ] 本番 merge 後、Production URL で disclaimer / variant ボタン表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)