### PR TITLE
fix(v4): Synthesize を別エンドポイントに分離し本番タイムアウトを解消

### DIFF
--- a/src/app/api/pipeline/route.ts
+++ b/src/app/api/pipeline/route.ts
@@ -1,5 +1,7 @@
 // Socra パイプライン SSE エンドポイント
 // 5段パイプラインを順次実行し、各ステージの結果をSSEでストリーミング
+// Note: runSynthesize は quick mode（軽量応答）でのみ使用。
+// フルモードの Synthesis は /api/pipeline/synthesize へ分離（2026-04-25）。
 import { runStructure, runObserve, runDeliberateSequential, runVerify, runSynthesize, runRouting, runFocusPoint, runPreMortem } from '@/lib/pipeline/engine'
 import { detectCrisis, getCrisisResponse } from '@/lib/safety'
 import type { SSEEvent, MemoryContext } from '@/types'
@@ -170,15 +172,17 @@ export async function POST(req: Request) {
             }
           }
 
-          // ── Stage 4: 青/統合 ────────────────────────
-          send({ type: 'stage:start', stage: 'synthesize', data: null, timestamp: now() })
-          const synthesis = await runSynthesize(structured, observation.facts, deliberation.agents, verification, undefined, userName, round, memoryContext)
-          send({ type: 'stage:complete', stage: 'synthesize', data: synthesis, timestamp: now() })
+          // ── Synthesis は別エンドポイント /api/pipeline/synthesize に分離 ─────
+          // 2026-04-25: Vercel maxDuration 300秒の二重消費を回避するため、
+          // メインパイプラインは Pre-mortem 完了で打ち切る。
+          // クライアント側（usePipeline）が pipeline:complete を受け取った後、
+          // structured/observation/deliberation/verification/preMortem を渡して
+          // /api/pipeline/synthesize を呼び出す責務を持つ。
 
-          // ── 完了 ────────────────────────────────────
+          // ── 完了（Synthesis 抜き）────────────────────────
           send({
             type: 'pipeline:complete',
-            data: { structured, observation, deliberation, verification, preMortem, synthesis, routing },
+            data: { structured, observation, deliberation, verification, preMortem, synthesis: null, routing },
             timestamp: now(),
           })
         }

--- a/src/app/api/pipeline/synthesize/route.ts
+++ b/src/app/api/pipeline/synthesize/route.ts
@@ -1,0 +1,70 @@
+// Socra v4: Synthesize 分離 API
+// 2026-04-25: メインパイプライン /api/pipeline は Pre-mortem 完了で打ち切り、
+// Synthesis（叡の最終統合）を別エンドポイントに分離して Vercel maxDuration 300秒の
+// 二重消費を回避する。
+import { runSynthesize } from '@/lib/pipeline/engine'
+import type {
+  StructuredQuestion,
+  Fact,
+  AgentResponse,
+  VerificationResult,
+  MemoryContext,
+} from '@/types'
+
+export const maxDuration = 120  // 単独 Synthesis は通常 30-60 秒。余裕を持って 120 秒。
+export const dynamic = 'force-dynamic'
+
+interface SynthesizeRequest {
+  structured: StructuredQuestion
+  facts?: Fact[]
+  agents?: AgentResponse[]
+  verification?: VerificationResult | null
+  quickReason?: string
+  userName?: string
+  round?: number
+  memoryContext?: MemoryContext
+}
+
+export async function POST(req: Request) {
+  let body: SynthesizeRequest
+  try {
+    body = await req.json() as SynthesizeRequest
+  } catch {
+    return new Response(JSON.stringify({ error: 'invalid json' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  const { structured, facts, agents, verification, quickReason, userName, round, memoryContext } = body
+
+  if (!structured || typeof structured.clarified !== 'string') {
+    return new Response(JSON.stringify({ error: 'structured question is required' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  try {
+    const synthesis = await runSynthesize(
+      structured,
+      facts ?? [],
+      agents ?? [],
+      verification ?? { hat: 'blue', model: 'openai', contradictions: [], factGaps: [], overallConsistency: 100 },
+      quickReason,
+      userName,
+      typeof round === 'number' ? round : 0,
+      memoryContext,
+    )
+    return new Response(JSON.stringify(synthesis), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'synthesize failed'
+    return new Response(JSON.stringify({ error: msg }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+}

--- a/src/lib/usePipeline.ts
+++ b/src/lib/usePipeline.ts
@@ -307,9 +307,76 @@ export function usePipeline() {
               }
               break
 
-            case 'pipeline:complete':
-              setState(prev => ({ ...prev, status: 'complete', currentStage: null }))
+            case 'pipeline:complete': {
+              // 2026-04-25: Synthesis 分離後の挙動。
+              // - Quick mode: event.data.synthesis が存在 → 即 complete
+              // - Full mode: synthesis === null → /api/pipeline/synthesize を別 fetch
+              const completeData = event.data as {
+                structured?: StructuredQuestion
+                observation?: ObservationResult
+                deliberation?: { agents?: AgentResponse[] }
+                verification?: VerificationResult
+                preMortem?: PreMortemResult | null
+                synthesis?: SynthesisResult | null
+              }
+
+              if (completeData?.synthesis) {
+                // Quick mode（叡が単独応答）: 既に synthesis がある
+                setState(prev => ({ ...prev, status: 'complete', currentStage: null }))
+                break
+              }
+
+              // Full mode: Synthesis を別エンドポイントで非同期取得
+              setState(prev => ({ ...prev, currentStage: 'synthesize' as PipelineStage }))
+              addTimeline({
+                id: `stage-synthesize-start-${Date.now()}`,
+                type: 'system',
+                stage: 'synthesize',
+                content: STAGE_LABELS['synthesize'],
+                timestamp: new Date().toISOString(),
+              })
+
+              ;(async () => {
+                try {
+                  const res = await fetch('/api/pipeline/synthesize', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                      structured: completeData.structured,
+                      facts: completeData.observation?.facts ?? [],
+                      agents: completeData.deliberation?.agents ?? [],
+                      verification: completeData.verification,
+                      userName,
+                      round: currentRound,
+                      memoryContext,
+                    }),
+                  })
+                  if (!res.ok) {
+                    const errBody = await res.json().catch(() => ({ error: `HTTP ${res.status}` }))
+                    throw new Error(typeof errBody.error === 'string' ? errBody.error : 'synthesize failed')
+                  }
+                  const syn = await res.json() as SynthesisResult
+                  setState(prev => ({ ...prev, synthesis: syn, status: 'complete', currentStage: null }))
+                  addTimeline({
+                    id: `ei-synthesis-${Date.now()}`,
+                    type: 'synthesis',
+                    name: 'Ei',
+                    hat: 'blue',
+                    stage: 'synthesize',
+                    content: syn.recommendation,
+                    timestamp: new Date().toISOString(),
+                  })
+                } catch (err) {
+                  setState(prev => ({
+                    ...prev,
+                    status: 'error',
+                    currentStage: null,
+                    error: err instanceof Error ? err.message : 'synthesize fetch failed',
+                  }))
+                }
+              })()
               break
+            }
 
             case 'pipeline:error':
               const errData = event.data as { error: string }
@@ -365,6 +432,21 @@ export function usePipeline() {
       }
       } finally {
         reader.cancel().catch(() => {})
+        // 2026-04-25: SSE が done で終了したのに pipeline:complete / pipeline:error が
+        // 受信されないケース（Vercel maxDuration 強制終了など）への防御。
+        // currentStage === 'synthesize' は分離した synthesize fetch が進行中の正常状態
+        // なので除外する。
+        setState(prev => {
+          if (prev.status === 'running' && prev.currentStage !== 'synthesize') {
+            return {
+              ...prev,
+              status: 'error',
+              currentStage: null,
+              error: 'パイプラインが予期せず終了しました。再試行してください。',
+            }
+          }
+          return prev
+        })
       }
     } catch (err) {
       setState(prev => ({


### PR DESCRIPTION
## 背景
本番（socra-seven）で Synthesis フェーズ中に \"Ei is synthesizing...\" のまま画面が固まり、操作不能になる事象を確認。

## 原因
Vercel の \`maxDuration = 300秒\` に対し、1リクエスト内で
\`structure → observe → deliberate → verify → premortem → synthesize\`
を逐次実行すると、Synthesis 開始時点で残り時間が枯渇する。Opus 4.7 の長文応答が打ち切られ、SSE が **無音切断**（\`pipeline:complete\` も \`pipeline:error\` も来ない）するため、クライアントが \`running\` のまま停止する。

## 修正
### 1. \`POST /api/pipeline/synthesize\` 新規追加（maxDuration=120秒）
Pre-mortem 完了後の入力を受け取り、Synthesis のみ単独実行。

### 2. メイン \`/api/pipeline\` を Pre-mortem 完了で終了
フルモードでは \`synthesis: null\` を含めて \`pipeline:complete\` を返す。Quick mode は1リクエストで完結（短時間なので分離不要）。

### 3. \`usePipeline\` の改修
- \`pipeline:complete\` 受信時に synthesis が null なら自動で \`/api/pipeline/synthesize\` を fetch
- \`finally\` で SSE が無音切断された場合（\`running\` のまま & not synthesizing）に \`status='error'\` に遷移させる防御

## 効果
- メインパイプラインの maxDuration 消費は Pre-mortem 完了までに収まる
- Synthesis は 120 秒の独立予算を持てる
- 本番タイムアウトが起きてもクライアントがエラー表示に遷移し固まらない

## Test plan
- [x] \`tsc --noEmit\` エラーなし
- [x] \`next lint\` 新規警告なし
- [ ] Vercel Preview で /api/pipeline と /api/pipeline/synthesize の連携が動作
- [ ] 本番で「電子基板実装×組立の工場にAI＋ロボット自動化を導入すべきか」の問いを再走らせ、Synthesis 完了まで通ること
- [ ] Synthesis 失敗時に固まらず error 表示に遷移すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)