### PR TITLE
fix(v4): Pre-mortem も別エンドポイントに分離（D案）

### DIFF
--- a/src/app/api/pipeline/premortem/route.ts
+++ b/src/app/api/pipeline/premortem/route.ts
@@ -1,0 +1,62 @@
+// Socra v4: Pre-mortem 分離 API
+// 2026-04-25: メイン /api/pipeline は observe→deliberate→verify までで終了し、
+// Pre-mortem（叡の Phase 4・時間の座）はクライアントから別エンドポイントで呼ぶ。
+// これによりメインパイプラインの maxDuration 300秒消費を観察+討論+検証の範囲に
+// 抑える（Anthropic レイテンシが高い日でもタイムアウトしない）。
+import { runPreMortem } from '@/lib/pipeline/engine'
+import type {
+  StructuredQuestion,
+  Fact,
+  AgentResponse,
+  VerificationResult,
+} from '@/types'
+
+export const maxDuration = 90  // Pre-mortem 単独は通常 30-50 秒。余裕を持って 90 秒。
+export const dynamic = 'force-dynamic'
+
+interface PreMortemRequest {
+  structured: StructuredQuestion
+  facts?: Fact[]
+  agents?: AgentResponse[]
+  verification?: VerificationResult | null
+}
+
+export async function POST(req: Request) {
+  let body: PreMortemRequest
+  try {
+    body = await req.json() as PreMortemRequest
+  } catch {
+    return new Response(JSON.stringify({ error: 'invalid json' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  const { structured, facts, agents, verification } = body
+
+  if (!structured || typeof structured.clarified !== 'string') {
+    return new Response(JSON.stringify({ error: 'structured question is required' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  try {
+    const preMortem = await runPreMortem(
+      structured,
+      facts ?? [],
+      agents ?? [],
+      verification ?? { hat: 'blue', model: 'openai', contradictions: [], factGaps: [], overallConsistency: 100 },
+    )
+    return new Response(JSON.stringify(preMortem), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'premortem failed'
+    return new Response(JSON.stringify({ error: msg }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+}

--- a/src/app/api/pipeline/route.ts
+++ b/src/app/api/pipeline/route.ts
@@ -1,15 +1,22 @@
 // Socra パイプライン SSE エンドポイント
 // 5段パイプラインを順次実行し、各ステージの結果をSSEでストリーミング
-// Note: runSynthesize は quick mode（軽量応答）でのみ使用。
-// フルモードの Synthesis は /api/pipeline/synthesize へ分離（2026-04-25）。
-import { runStructure, runObserve, runDeliberateSequential, runVerify, runSynthesize, runRouting, runFocusPoint, runPreMortem } from '@/lib/pipeline/engine'
+// Note:
+//   - quick mode（叡が単独応答）のみ runSynthesize を本ルート内で使う
+//   - full mode の Pre-mortem は /api/pipeline/premortem へ分離（2026-04-25）
+//   - full mode の Synthesis は /api/pipeline/synthesize へ分離（2026-04-25）
+//   メインルートは observe → deliberate → verify までで終了し、maxDuration 300 秒の
+//   消費を抑える。
+import { runStructure, runObserve, runDeliberateSequential, runVerify, runSynthesize, runRouting, runFocusPoint } from '@/lib/pipeline/engine'
 import { detectCrisis, getCrisisResponse } from '@/lib/safety'
 import type { SSEEvent, MemoryContext } from '@/types'
 
 export const maxDuration = 300  // Vercel Pro: 最大300秒。Web検索込みで余裕を持つ
 
 export async function POST(req: Request) {
-  const { question, context, locale, userName, round = 0, memoryContext } = await req.json() as {
+  // round / memoryContext は Pre-mortem / Synthesis 分離後はメインルートで使わないが、
+  // クライアント既存契約は維持する（クライアントは round と memoryContext を Pre-mortem
+  // と Synthesize の各エンドポイントに渡す）。
+  const { question, context, locale, userName, memoryContext } = await req.json() as {
     question: string; context?: string; locale?: string; userName?: string; round?: number; memoryContext?: MemoryContext
   }
 
@@ -157,32 +164,15 @@ export async function POST(req: Request) {
           const verification = await runVerify(structured, deliberation.agents)
           send({ type: 'stage:complete', stage: 'verify', data: verification, timestamp: now() })
 
-          // ── Stage 3.5: 叡 — Pre-mortem（v4 Phase 4・時間の座）────
-          // round 0（初回）のみ実行。フォローアップラウンドでは叡は現在に戻って対話する。
-          let preMortem = null
-          if (round === 0) {
-            send({ type: 'stage:start', stage: 'premortem', data: null, timestamp: now() })
-            try {
-              preMortem = await runPreMortem(structured, observation.facts, deliberation.agents, verification)
-              send({ type: 'stage:complete', stage: 'premortem', data: preMortem, timestamp: now() })
-            } catch (err) {
-              // Pre-mortem 失敗時は pipeline 全体を落とさず、synthesize へ続行
-              const msg = err instanceof Error ? err.message : 'premortem failed'
-              send({ type: 'stage:complete', stage: 'premortem', data: { error: msg }, timestamp: now() })
-            }
-          }
+          // ── Pre-mortem と Synthesis は別エンドポイントへ分離（2026-04-25）─────
+          // /api/pipeline/premortem  — round 0 のときクライアントが続けて呼ぶ
+          // /api/pipeline/synthesize — クライアントが最後に呼ぶ
+          // メインパイプラインは verify までで終了し、maxDuration 消費を抑える。
 
-          // ── Synthesis は別エンドポイント /api/pipeline/synthesize に分離 ─────
-          // 2026-04-25: Vercel maxDuration 300秒の二重消費を回避するため、
-          // メインパイプラインは Pre-mortem 完了で打ち切る。
-          // クライアント側（usePipeline）が pipeline:complete を受け取った後、
-          // structured/observation/deliberation/verification/preMortem を渡して
-          // /api/pipeline/synthesize を呼び出す責務を持つ。
-
-          // ── 完了（Synthesis 抜き）────────────────────────
+          // ── 完了（Pre-mortem / Synthesis 抜き）────────────────────────
           send({
             type: 'pipeline:complete',
-            data: { structured, observation, deliberation, verification, preMortem, synthesis: null, routing },
+            data: { structured, observation, deliberation, verification, preMortem: null, synthesis: null, routing },
             timestamp: now(),
           })
         }

--- a/src/lib/usePipeline.ts
+++ b/src/lib/usePipeline.ts
@@ -308,9 +308,10 @@ export function usePipeline() {
               break
 
             case 'pipeline:complete': {
-              // 2026-04-25: Synthesis 分離後の挙動。
+              // 2026-04-25: Pre-mortem / Synthesis 分離後の挙動。
               // - Quick mode: event.data.synthesis が存在 → 即 complete
-              // - Full mode: synthesis === null → /api/pipeline/synthesize を別 fetch
+              // - Full mode round 0: premortem fetch → synthesize fetch
+              // - Full mode round > 0: synthesize fetch のみ
               const completeData = event.data as {
                 structured?: StructuredQuestion
                 observation?: ObservationResult
@@ -326,26 +327,74 @@ export function usePipeline() {
                 break
               }
 
-              // Full mode: Synthesis を別エンドポイントで非同期取得
-              setState(prev => ({ ...prev, currentStage: 'synthesize' as PipelineStage }))
-              addTimeline({
-                id: `stage-synthesize-start-${Date.now()}`,
-                type: 'system',
-                stage: 'synthesize',
-                content: STAGE_LABELS['synthesize'],
-                timestamp: new Date().toISOString(),
-              })
+              // Full mode: Pre-mortem（round 0 のみ）→ Synthesis を順次取得
+              const facts = completeData.observation?.facts ?? []
+              const agents = completeData.deliberation?.agents ?? []
+              const verification = completeData.verification
+              const structured = completeData.structured
 
               ;(async () => {
+                // ── Phase 4: Pre-mortem（round 0 のみ）──
+                if (currentRound === 0) {
+                  setState(prev => ({ ...prev, currentStage: 'premortem' as PipelineStage }))
+                  addTimeline({
+                    id: `stage-premortem-start-${Date.now()}`,
+                    type: 'system',
+                    stage: 'premortem',
+                    content: STAGE_LABELS['premortem'],
+                    timestamp: new Date().toISOString(),
+                  })
+                  try {
+                    const pmRes = await fetch('/api/pipeline/premortem', {
+                      method: 'POST',
+                      headers: { 'Content-Type': 'application/json' },
+                      body: JSON.stringify({ structured, facts, agents, verification }),
+                    })
+                    if (!pmRes.ok) {
+                      // Pre-mortem 失敗は致命傷ではない。warning だけ残して synthesize へ続行
+                      const errBody = await pmRes.json().catch(() => ({ error: `HTTP ${pmRes.status}` }))
+                      setState(prev => ({
+                        ...prev,
+                        variantError: typeof errBody.error === 'string' ? errBody.error : 'premortem failed',
+                      }))
+                    } else {
+                      const pm = await pmRes.json() as PreMortemResult
+                      if (pm && typeof pm.narrative === 'string') {
+                        setState(prev => ({ ...prev, preMortem: pm }))
+                        addTimeline({
+                          id: `ei-premortem-${Date.now()}`,
+                          type: 'synthesis',
+                          name: 'Ei',
+                          hat: 'blue',
+                          stage: 'premortem',
+                          content: [pm.scenarioTitle, '', pm.narrative, '', pm.coreQuestionBack].filter(Boolean).join('\n'),
+                          timestamp: new Date().toISOString(),
+                        })
+                      }
+                    }
+                  } catch {
+                    // Pre-mortem fetch失敗。synthesize へ続行
+                  }
+                }
+
+                // ── Stage 4: Synthesis ──
+                setState(prev => ({ ...prev, currentStage: 'synthesize' as PipelineStage }))
+                addTimeline({
+                  id: `stage-synthesize-start-${Date.now()}`,
+                  type: 'system',
+                  stage: 'synthesize',
+                  content: STAGE_LABELS['synthesize'],
+                  timestamp: new Date().toISOString(),
+                })
                 try {
                   const res = await fetch('/api/pipeline/synthesize', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({
-                      structured: completeData.structured,
-                      facts: completeData.observation?.facts ?? [],
-                      agents: completeData.deliberation?.agents ?? [],
-                      verification: completeData.verification,
+                      structured,
+                      facts,
+                      agents,
+                      verification,
                       userName,
                       round: currentRound,
                       memoryContext,
@@ -434,10 +483,11 @@ export function usePipeline() {
         reader.cancel().catch(() => {})
         // 2026-04-25: SSE が done で終了したのに pipeline:complete / pipeline:error が
         // 受信されないケース（Vercel maxDuration 強制終了など）への防御。
-        // currentStage === 'synthesize' は分離した synthesize fetch が進行中の正常状態
-        // なので除外する。
+        // currentStage が 'premortem' / 'synthesize' は分離した fetch が進行中の
+        // 正常状態なので除外する。
         setState(prev => {
-          if (prev.status === 'running' && prev.currentStage !== 'synthesize') {
+          const inPostPipelineFetch = prev.currentStage === 'premortem' || prev.currentStage === 'synthesize'
+          if (prev.status === 'running' && !inPostPipelineFetch) {
             return {
               ...prev,
               status: 'error',


### PR DESCRIPTION
## 背景
PR #8 で Synthesis を分離したが、本番で再度実機テストした結果、依然として \`Vercel Runtime Timeout Error: Task timed out after 300 seconds\` が発生（観察→討論の段階で詰まる・本日 Anthropic レイテンシ高め）。

## 修正
メインパイプラインは **verify までで打ち切り**、Pre-mortem も別エンドポイントへ分離。

### 1. \`POST /api/pipeline/premortem\`（新規・maxDuration=90秒）
既存の \`runPreMortem\` を流用し、Pre-mortem のみ単独実行。

### 2. メイン \`/api/pipeline\`
verify 完了で \`pipeline:complete\` 発火。\`preMortem: null\` / \`synthesis: null\` を含む。

### 3. \`usePipeline\`
\`pipeline:complete\` 受信時に \`currentRound === 0\` なら：
1. \`/api/pipeline/premortem\` fetch（失敗しても続行）
2. \`/api/pipeline/synthesize\` fetch
の順次実行。

\`finally\` の防御も \`'premortem' / 'synthesize'\` の post-pipeline fetch 中で誤発火しないよう拡張。

## 効果
- メインパイプラインの maxDuration 消費が \`structure → observe → focusPoint → deliberate → verify\` までに収まる
- Pre-mortem は 90 秒の独立予算
- Synthesis は 120 秒の独立予算
- 合計時間予算: 300 + 90 + 120 = 510 秒（旧 300 秒）

## Test plan
- [x] \`tsc --noEmit\` エラーなし
- [x] \`next lint\` 新規警告なし
- [x] \`next build\` 成功（/api/pipeline/premortem ルート登録確認）
- [ ] 本番で「電子基板実装×組立の工場にAI＋ロボット自動化を導入すべきか」を再走らせて Synthesis まで完走
- [ ] round > 0（フォローアップ）で Pre-mortem がスキップされ Synthesis のみ呼ばれること

🤖 Generated with [Claude Code](https://claude.com/claude-code)