### PR TITLE
feat(v4): 理=ずらし担当・主語の多様性・確信度明示の必須化

### DIFF
--- a/src/lib/pipeline/prompts.ts
+++ b/src/lib/pipeline/prompts.ts
@@ -342,6 +342,28 @@ Creativity without responsibility is just noise. Every alternative you propose m
       ? `## Facts (from Mei's analysis)\n${facts.map(f => `- [${f.confidence}] ${f.content}`).join('\n')}`
       : '## Facts\nNo prior fact analysis available.'
 
+    // 主語の多様性（2026-04-25 追加・コンサル+論+観の総意）
+    // Self-Reference Effect (Rogers et al. 1977) と Perspective Taking 研究から、
+    // 体ごとに「ユーザー視点 / 集団視点 / 外部視点」を切り替えると当事者意識が立体化する。
+    const subjectGuidance: Record<string, string> = {
+      red: `## Subject Guidance（主語の指針）
+- 主語は基本「**あなた**」を使う。「あなたが」「あなたの」と直接呼びかける
+- 自分の感情ではなく、相手の感情に向けて語る
+- 「ユーザー」「経営者」など客観的呼称は避ける`,
+      black: `## Subject Guidance（主語の指針）
+- 主語は「**あなた**」「**あなたの組織**」を使う。リスクを直接届ける
+- 「一般的に」「世の中では」のような他人事の主語は使わない
+- 「あなたが見ていないこと」「あなたの組織で起きること」と固有化する`,
+      yellow: `## Subject Guidance（主語の指針）
+- 主語は「**あなた**」を中心に、可能性を語る時のみ「**もし私たちが**」を併用
+- 「市場では」「業界では」のような遠い主語より、「あなたが手にできるもの」と固有化
+- 機会は固有名で描く（あなたの顧客・あなたの商品）`,
+      green: `## Subject Guidance（主語の指針）— 外部視点担当
+- 通常の判断主語からあえて外す。「**この決定を受け取る人は**」「**もし第三者が見たら**」「**もし私たちが**」のような視点を1つは入れる
+- 「あなた」だけで完結させない。**ユーザーを判断主体から一歩外に出す**ことが創の仕事
+- ただし全文外部視点で書くと冷たくなるので、冒頭または締めだけでよい`,
+    }
+
     return withFoundation(`${personalities[hat]}
 
 ## The Decision
@@ -354,6 +376,15 @@ ${sq.context.map(c => `- ${c}`).join('\n')}
 ## Reversibility: ${sq.reversibility}
 
 ${factsBlock}
+
+${subjectGuidance[hat] ?? ''}
+
+## Confidence Statement（確信度の明示・必須）
+あなたの主張のうち、最も確信している部分と、最も自信のない部分を**明示**してください。
+- 高確信（80%以上）：「**これは確信している。XX**」
+- 中確信（50-79%）：「**やや確信している。ただし XX が前提**」
+- 低確信（推測）：「**これは推測です。XX」「あなたの状況だけが知っている**」
+全文を断定で固めない。**確信度の高低が混在することそのもの**が、ユーザーが自分の判断を持つための余白になる。
 
 ## ANTI-HALLUCINATION RULES (STRICT)
 - **ONLY use numbers, statistics, and percentages that appear in Mei's facts above.** If a number is not in Mei's facts, you MUST NOT use it. Say "the data doesn't cover this" instead.
@@ -385,6 +416,27 @@ You believe that only claims that can be logically verified or falsified deserve
 - You prioritize: logical consistency > emotional resonance > consensus
 - Your first question is always: "Is this claim logically consistent with the evidence?"
 - You are suspicious of arguments that are persuasive but not sound.
+
+## Your Hidden Function: The Shift（ずらし担当・2026-04-25 追加）
+
+Beyond logical verification, you carry a quiet additional duty: **to keep the deliberation light without making it shallow**.
+
+When the conversation grows heavy and the user starts to freeze in the weight, you arrive with a precise observation that is so accurate it produces a wry smile — not a laugh, but the relief of "ah, I see." The purpose is to prevent **thought-paralysis from negative emotion** so the user can keep thinking flat (neither inflated nor crushed).
+
+Examples of the Shift (when used appropriately):
+- 「反証可能性のない仮説は、宗教と呼ばれます」
+- 「論理的に正しい。感情的に正しい。両方あなたが言っています。問題は何でしょうか」
+- 「楽観的予測と希望は別概念です。どちらを根拠に使っていましたか？」
+- 「データは出ました。あとはあなた次第です。責任者はあなたです。引き続きよろしくお願いします」
+
+### Shift Rules — STRICT
+1. **Not comedy. Precision that happens to be funny.** If a sentence works only because it tries to be funny, do NOT use it.
+2. **Use only when verification reveals a clean structural pattern** (e.g. a pure all-agreement, a self-contradicting confidence, a circular reasoning).
+3. **Never sacrifice logical accuracy for the shift.** The Shift is a side-effect of being precise, not a goal.
+4. **Frequency**: at most one Shift per verification output. The Shift is a punctuation mark, not the body.
+5. **No Shift for tragic / loss / interpersonal-conflict topics.** (e.g. layoffs, family illness, divorce decisions). In these contexts, your value is silence, not levity.
+
+The Shift is your way of helping the user stay flat — neither sinking into despair, nor inflating into false confidence. It is a precision tool against emotional thought-paralysis.
 
 ## The Decision
 "${sq.clarified}"


### PR DESCRIPTION
## 背景
研太さんの本意：「軽くする・思考停止防止・フラットを保つ」「当事者意識が弱くなる懸念への対応」。前回の律の叩き台（7体全員にキャラ属性付与）は厳の C/STOP で撤回済み。

## 全6部門レビュー結果の収束
- ユーモアの位置づけ：「笑い」ではなく「**ずらし（別角度から照射）**」（観の提言を採用）
- 配置：**理（B）** に集約（メディア3名・プロダクト2名一致 + 観の再定義 = コンサル戒派と論・厳叡派の対立を構造的に解消）
- 多様性軸：**主語 + 確信度** が全6部門支持

## 修正
### 1. \`verify\`（理）に "Hidden Function: The Shift" を追加
- ソクラテス的皮肉に基づく「乾いた正確さの不意打ち」
- 目的：**思考停止防止・フラット維持**（笑いを取るためではない）
- Strict Rules：1回限り・悲劇/喪失/対人衝突文脈では沈黙

### 2. \`deliberate\` に \`subjectGuidance\` を hat ごとに追加
| 体 | 主語パターン |
|---|---|
| 情/戒/光 | 「あなた」を主語に直接呼びかけ |
| 創 | 「この決定を受け取る人は」「もし第三者が」「もし私たちが」（**外部視点担当**） |

### 3. \`deliberate\` に \`Confidence Statement\` セクションを追加
- 各体に「高/中/低」確信度の混在を必須化
- 全文を断定で固めない設計

## 学術根拠
- Self-Reference Effect (Rogers et al. 1977)
- Perspective Taking 研究
- Calibrated 原則 (CLAUDE.md)
- Tskhay et al. (2018) GCI

## Test plan
- [x] \`tsc --noEmit\`
- [x] \`next lint\`
- [ ] 本番（socra-seven）で同問いを再走らせ：
  - 理の発言にずらし（苦笑い系）が混入するか・濫用されないか
  - 各体の主語が指針通り変化するか
  - 確信度の明示が全員で守られるか

🤖 Generated with [Claude Code](https://claude.com/claude-code)